### PR TITLE
Avoid EllipsizeTextView to crash when height is zero

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.dinuscxj.ellipsizeexample"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ellipsizetextview/build.gradle
+++ b/ellipsizetextview/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 11

--- a/ellipsizetextview/src/main/java/com/dinuscxj/ellipsize/EllipsizeTextView.java
+++ b/ellipsizetextview/src/main/java/com/dinuscxj/ellipsize/EllipsizeTextView.java
@@ -79,7 +79,7 @@ public class EllipsizeTextView extends TextView {
                 originText.length() - mEllipsizeIndex, originText.length());
 
         final int width = layout.getWidth() - getPaddingLeft() - getPaddingRight();
-        final int maxLineCount = computeMaxLineCount(layout);
+        final int maxLineCount = Math.max(1, computeMaxLineCount(layout));
         final int lastLineWidth = (int) layout.getLineWidth(maxLineCount - 1);
         final int mLastCharacterIndex = layout.getLineEnd(maxLineCount - 1);
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Fri May 26 10:30:08 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip


### PR DESCRIPTION
This PR fixes a crash happening when `EllipsizeTextView` height is zero. Also includes a bump to the gradle configuration.